### PR TITLE
Fix size of search icon

### DIFF
--- a/dist/icons/search.svg
+++ b/dist/icons/search.svg
@@ -1,4 +1,4 @@
-<svg id="i-search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="6.25%">
+<svg id="i-search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="6.25%">
     <circle cx="14" cy="14" r="12" />
     <path d="M23 23 L30 30"  />
 </svg>


### PR DESCRIPTION
I found `width=` and `height=` are missing for `i-search` icon. Fixed them.