### PR TITLE
Add a link to yet another react component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If you decide to use a larger `stroke-width` with `stroke-linejoin: miter` (Squa
 
 ## Forks & Extensions
 - [Bytesize Icons as React Components](https://github.com/abdelhai/react-bytesize-icons) by [Mustafa Abdelhai](https://github.com/abdelhai/)
+- [Yet Another Bytesize Icons as React Component](https://github.com/rhysd/react-component-bytesize-icons) by [@rhysd](https://github.com/rhysd)
 
 ## File Size
 


### PR DESCRIPTION
Hi, I add yet another react component library for bytesize icons because react-bytesize-icons exposes inner `<svg>` element's attributes such as `strokeWidth`. I'll be happy if you add it to the list. Thanks.